### PR TITLE
run scripts in init.d automatically

### DIFF
--- a/config/river/init
+++ b/config/river/init
@@ -1,3 +1,3 @@
 #!/bin/zsh
 
-source <(cat $XDG_CONFIG_HOME/river/init.d/*)
+source <(cat $XDG_CONFIG_HOME/river/init.d/*) &

--- a/config/river/init
+++ b/config/river/init
@@ -1,9 +1,3 @@
 #!/bin/zsh
 
-${XDG_CONFIG_HOME}/river/init.d/appearance &
-${XDG_CONFIG_HOME}/river/init.d/startup &
-${XDG_CONFIG_HOME}/river/init.d/input &
-${XDG_CONFIG_HOME}/river/init.d/map &
-${XDG_CONFIG_HOME}/river/init.d/behaviour &
-${XDG_CONFIG_HOME}/river/init.d/layout &
-
+source <(cat $XDG_CONFIG_HOME/river/init.d/*)


### PR DESCRIPTION
This runs all scripts in the init.d folder instead of manually running each one.

Also, it uses `source`, which avoids subshells.

If you want posix compliancy, i.e. to work with `/bin/sh`, this can also be used:
```sh
for f in $XDG_CONFIG_HOME/river/init.d/*; do . $f; done
```
